### PR TITLE
Reorganizing the documentation for Quark v0.2.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,16 +9,33 @@ Welcome to Quark's documentation!
 
 .. toctree::
    :maxdepth: 1
-   
-   What's New <whats_new.rst>
-   Quark Overview <quark_overview.rst>
+   :caption: Release Notes
+
+   Release V0.2.0 <release_note.rst>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Getting Started
+
    Installation <install.rst>
-   Getting Started <getting_started.rst>
-   Highlight Features <highlight_features.rst>
-   User Guide <user_guide.rst>
-   APIs <apis.rst>
-   Examples <example.rst>
-   Release Note <release_note.rst>
+   Quark Overview <quark_overview.rst>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: PyTorch
+
+   Quark with PyTorch <pytorch_overview.rst>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: ONNX
+   
+   Quark with ONNX <onnx_overview.rst>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: FAQ
+
    FAQ <faq.rst>
 
 ..

--- a/docs/onnx/index.rst
+++ b/docs/onnx/index.rst
@@ -1,0 +1,20 @@
+Quark with ONNX!
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   Getting Started <getting_started.rst>
+   User Guide <user_guide.rst>
+   Examples <onnx_examples.rst>
+   APIs <onnx_apis.rst>
+   Advanced Features <onnx_adv_features.rst>
+
+..
+  ------------
+
+  #####################################
+  License
+  #####################################
+
+  Quark is licensed under MIT License. Refer to the LICENSE file for the full license text and copyright notice.

--- a/docs/onnx/onnx_adv_features.rst
+++ b/docs/onnx/onnx_adv_features.rst
@@ -1,0 +1,20 @@
+Advanced Features
+==================
+
+This page introduces some key features of Quark. Please refere to the
+`user guide <./user_guide.html>`__ for the more details of other features
+of Quark.
+
+
+Quark for ONNX
+--------------
+
+-  `AdaRound and AdaQuant <./tutorial_adaround_adaquant.html>`__
+-  `Mixed Precision <./tutorial_mix_precision.html>`__
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/onnx/onnx_apis.rst
+++ b/docs/onnx/onnx_apis.rst
@@ -1,0 +1,24 @@
+Quark APIs for ONNX
+===================
+
+**User facing APIs:**
+
+.. toctree::
+   :maxdepth: 2
+
+   Quantization <../autoapi/quark/onnx/quantization/api/index.rst>
+   Optimization <../autoapi/quark/onnx/optimize/index.rst>
+   Calibration <../autoapi/quark/onnx/calibrate/index.rst>
+   ONNX Quantizer <../autoapi/quark/onnx/onnx_quantizer/index.rst>
+   QDQ Quantizer <../autoapi/quark/onnx/qdq_quantizer/index.rst>
+   Configuration <../autoapi/quark/onnx/quantization/config/config/index.rst>
+   Quantization Utilities <../autoapi/quark/onnx/quant_utils/index.rst>
+
+..
+  ------------
+
+  #####################################
+  License
+  #####################################
+
+  Quark is licensed under MIT License. Refer to the LICENSE file for the full license text and copyright notice.

--- a/docs/onnx/onnx_examples.rst
+++ b/docs/onnx/onnx_examples.rst
@@ -1,0 +1,17 @@
+Examples
+========
+
+Examples to run Quark for ONNX. 
+   
+* `Image Classification Quantization <../quark_example_onnx_image_classification_gen.html>`__
+* `Fast Finetune AdaRound <../quark_examples_onnx_adaround_gen.html>`__
+* `Fast Finetune AdaQuant <../quark_example_onnx_adaquant_gen.html>`__
+* `Mixed Precision <../quark_onnx_example_mixed_precision_gen.html>`__
+* `Cross-Layer Equalization <../quark_example_onnx_cle_gen.html>`__
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/onnx/user_guide.rst
+++ b/docs/onnx/user_guide.rst
@@ -1,0 +1,27 @@
+Quark for ONNX
+==============
+
+There are several steps to quantize a floating-point model with
+``Quark for ONNX``:
+
+1. Load original float model
+2. Set quantization configuration
+3. Define datareader
+4. Use the Quark API to perform in-place replacement of the model's modules with quantized module.
+
+More details:
+
+* `Configuring Quark for ONNX <./onnx/user_guide_config_description.html>`__
+* `Adding Calibration Datasets <./onnx/user_guide_datareader.html>`__
+* `Feature Description <./onnx/user_guide_feature_description.html>`__
+* `Supported Datatype and OpType <./onnx/user_guide_supported_optype_datatype.html>`__
+* `Accuracy Improvement <./onnx/user_guide_accuracy_improvement.html>`__
+* `Optional Utilities <./onnx/user_guide_optional_utilities.html>`__
+* `Tools <./onnx/user_guide_tools.html>`__
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/onnx_overview.rst
+++ b/docs/onnx_overview.rst
@@ -1,0 +1,19 @@
+ONNX 
+====
+
+.. toctree::
+   :maxdepth: 1
+
+   Getting Started <onnx/getting_started.rst>
+   User Guide <onnx/user_guide.rst>
+   Examples <onnx/onnx_examples.rst>
+   APIs <onnx/onnx_apis.rst>
+   Advanced Features <onnx/onnx_adv_features.rst>
+
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/pytorch/index.rst
+++ b/docs/pytorch/index.rst
@@ -1,0 +1,23 @@
+Quark with PyTorch!
+===================
+
+**Quark** is a deep learning model quantization toolkit for quantizing models from PyTorch, ONNX and other frameworks. 
+It provides easy-to-use APIs for quantization and more advanced features than native frameworks, in support for multiple HW backends.
+
+.. toctree::
+   :maxdepth: 1
+   
+   Getting Started <getting_started.rst>
+   User Guide <user_guide.rst>
+   Examples <pytorch_examples.rst>
+   APIs <pytorch_apis.rst>
+   Advanced Features <pytorch_adv_features.rst>
+
+..
+  ------------
+
+  #####################################
+  License
+  #####################################
+
+  Quark is licensed under MIT License. Refer to the LICENSE file for the full license text and copyright notice.

--- a/docs/pytorch/pytorch_adv_features.rst
+++ b/docs/pytorch/pytorch_adv_features.rst
@@ -1,0 +1,20 @@
+Advanced Features
+==================
+
+This page introduces some key features of Quark. Please refere to the
+`user guide <./user_guide.html>`__ for the more details of other features
+of Quark.
+
+Quark for PyTorch
+-----------------
+
+-  `Bridge from Quark to llama.cpp <./tutorial_gguf.html>`__
+-  `Using MX (Microscaling) with Quark <./tutorial_mx.html>`__
+
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/pytorch/pytorch_apis.rst
+++ b/docs/pytorch/pytorch_apis.rst
@@ -1,0 +1,21 @@
+Quark APIs for PyTorch
+======================
+
+**User facing APIs:**
+
+.. toctree::
+   :maxdepth: 1
+
+   Quantization <../autoapi/quark/torch/quantization/api/index.rst>
+   Export <../autoapi/quark/torch/export/api/index.rst>
+   Quantizer Configuration <../autoapi/quark/torch/quantization/config/config/index.rst>
+   Exporter Configuration <../autoapi/quark/torch/export/config/config/index.rst>
+
+..
+  ------------
+
+  #####################################
+  License
+  #####################################
+
+  Quark is licensed under MIT License. Refer to the LICENSE file for the full license text and copyright notice.

--- a/docs/pytorch/pytorch_examples.rst
+++ b/docs/pytorch/pytorch_examples.rst
@@ -1,0 +1,18 @@
+Examples
+========
+
+Examples to run Quark for Pytorch. 
+
+* `Language Model Quantization & Export <../quark_example_torch_llm_gen.html>`__
+* `Diffusion Model Quantization & Export <../quark_example_torch_diffusers_gen.html>`__
+* `Vision Model Quantization using Quark FX Graph Mode <../quark_example_torch_vision_gen.html>`__
+* `Extension for Pytorch-light (AMD internal project) <../quark_example_torch_pytorch_light_gen.html>`__
+* `Extension for Brevitas <../quark_example_torch_brevitas_gen.html>`__
+
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/pytorch/user_guide.rst
+++ b/docs/pytorch/user_guide.rst
@@ -1,0 +1,26 @@
+Quark for PyTorch
+==========
+
+There are several steps to quantize a floating-point model with
+``Quark for PyTorch``:
+
+1. Load original float model
+2. Set quantization configuration
+3. Define dataloader
+4. Use the Quark API to perform in-place replacement of the model's modules with quantized module.
+5. (Optional) Export quantized model to other format such as ONNX
+
+More details:
+   
+* `Configuring Quark for PyTorch <./pytorch/user_guide_config_description.html>`__
+* `Adding Calibration Datasets <./pytorch/user_guide_dataloader.html>`__
+* `Exporting for ONNX & Json-Safetensors & GGUF <./pytorch/user_guide_exporting.html>`__
+* `Feature Description <./pytorch/user_guide_feature_description.html>`__
+
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->

--- a/docs/pytorch_overview.rst
+++ b/docs/pytorch_overview.rst
@@ -1,0 +1,18 @@
+PyTorch 
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   Getting Started <pytorch/getting_started.rst>
+   User Guide <pytorch/user_guide.rst>
+   Examples <pytorch/pytorch_examples.rst>
+   APIs <pytorch/pytorch_apis.rst>
+   Advanced Features <pytorch/pytorch_adv_features.rst>
+
+.. raw:: html
+
+   <!-- 
+   ## License
+   Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved. SPDX-License-Identifier: MIT
+   -->


### PR DESCRIPTION
- Moving getting started, user guide, example, APIs to PyTorch and ONNX frameworks

- Formatting the landing page for better overview